### PR TITLE
bugfix for worker error event, so it outputs error to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A worker emits the following events:
 * `emit('ready')`: when redis client is ready
 * `emit('listening')`: when listening for work
 * `emit('worker error', err)`: when a worker error occurs
-* `emit('work done', payload)`: when a worker finishes a piece of work
+* `emit('work done', work)`: when a worker finishes a piece of work
 * `emit('repush', payload)`: when a work unit is being repushed after failure
 * `emit('max retries', lastError, payload)`: when the maximum retries has been reached
 

--- a/tests/max_retries.js
+++ b/tests/max_retries.js
@@ -33,6 +33,11 @@ test('worker retries for maxRetries', function(t) {
   }
 
   var maxRetries = 0;
+
+  worker.on('worker error', function(err) {
+    t.equal('something awful has happened', err.message);
+  });
+
   worker.on('max retries', function(err, payload) {
     t.equal(++ maxRetries, payload);
   });

--- a/tests/worker-fetch-result.js
+++ b/tests/worker-fetch-result.js
@@ -24,6 +24,10 @@ test('creates worker without autoListen, fetches a message and gets a response',
   worker = Queue.worker(queue, work, workerOptions);
   worker.fetch();
 
+  worker.on('work done', function(work) {
+    t.deepEqual(work.payload, {a:1, b:2});
+  });
+
   function work(payload, cb) {
     cb();
     t.deepEqual(payload, {a:1, b:2});

--- a/worker.js
+++ b/worker.js
@@ -155,7 +155,7 @@ function createWorker(queueName, workerFn, options) {
 
     function onWorkerFinished(err) {
       if (err) {
-        self.emit('worker error');
+        self.emit('worker error', err);
         pending --;
         maybeRetry(err, work);
         if (options.autoListen) {


### PR DESCRIPTION
as reported in https://github.com/pgte/simple-redis-safe-work-queue/issues/11

this pull only does these 3 things:

1. fix the `worker error` event callback to return error
2. add a few tests to confirm `worker error` and `work done` are firing properly
3. edit doc to show that `work done` is returning `work` instead of `work.payload`