### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "dependencies": {
     "json-stringify-safe": "^5.0.0",
     "node-uuid": "^1.4.1",
-    "redis": "^0.10.3",
-    "xtend": "^3.0.0"
+    "redis": "^2.5.3",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "tap": "^0.4.11"


### PR DESCRIPTION
[node_redis](https://github.com/NodeRedis/node_redis) has improved a lot since the used version and I highly recommend to update to the newest one.

I also updated xtend as I could not see any BC in the new version. All tests pass but I don't know how well this library is tested.