### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,7 +1,7 @@
 var defaultClientOptions = require('./default_client_options');
 var EventEmitter = require('events').EventEmitter;
 var stringify = require('json-stringify-safe');
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var extend = require('xtend');
 var Redis = require('redis');
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "homepage": "https://github.com/pgte/simple-redis-safe-work-queue",
   "dependencies": {
     "json-stringify-safe": "^5.0.0",
-    "node-uuid": "^1.4.1",
     "redis": "^2.5.3",
+    "uuid": "^3.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/max_concurrency.js
+++ b/tests/max_concurrency.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/max_retries.js
+++ b/tests/max_retries.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/retries.js
+++ b/tests/retries.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/stalled.js
+++ b/tests/stalled.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/timeouts.js
+++ b/tests/timeouts.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/worker-fetch-invalidstate.js
+++ b/tests/worker-fetch-invalidstate.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/worker-fetch-noresult.js
+++ b/tests/worker-fetch-noresult.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/worker-fetch-result.js
+++ b/tests/worker-fetch-result.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 

--- a/tests/worker-no-autoListen-with-fetch.js
+++ b/tests/worker-no-autoListen-with-fetch.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../');
 

--- a/tests/worker-no-autoListen.js
+++ b/tests/worker-no-autoListen.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 var test = require('tap').test;
 var Queue = require('../')
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.